### PR TITLE
ci: use python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
 language: python
 cache: pip
 python:
-  - "3.5"
+  - "3.6"
 
 install: "pip install -r requirements.txt"
 


### PR DESCRIPTION
I don't think there are reasons to use 3.5 in 2017..