### PR TITLE
Fixed warning on downloads page

### DIFF
--- a/stories/skachat.rst
+++ b/stories/skachat.rst
@@ -18,7 +18,7 @@
 
 
 Для Windows и MacOS:
-------------
+-------------------------
 
 * `Fedora Media Writer
   <https://github.com/FedoraQt/MediaWriter/releases/latest>`__ -


### PR DESCRIPTION
Fixed warning on downloads page:

```
System Message: WARNING/2 (<string>, line 12)
Title underline too short.
```