### PR TITLE
Change host and disable comments

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -896,7 +896,7 @@ CONTENT_FOOTER_FORMATS = {
 # systems.  The following comment systems are supported by Nikola:
 #   disqus, facebook, googleplus, intensedebate, isso, livefyre, muut
 # You can leave this option blank to disable comments.
-COMMENT_SYSTEM = "googleplus"
+COMMENT_SYSTEM = ""
 # And you also need to add your COMMENT_SYSTEM_ID which
 # depends on what comment system you use. The default is
 # "nikolademo" which is a test account for Disqus. More information

--- a/utils/deploy.sh
+++ b/utils/deploy.sh
@@ -2,12 +2,13 @@
 
 RSH_STRING="/usr/bin/sshpass -p ${DEPLOY_PASSWORD} ssh -o StrictHostKeyChecking=no -l ${DEPLOY_USER}"
 
+HOST="212.227.198.243"
 DEST=${TRAVIS_BRANCH:-test}
 echo "Publishing to ${DEST}"
 
-rsync -rav --delete --rsh="${RSH_STRING}" output/ russianfedora.pro:~/"${DEST}"
+rsync -rav --delete --rsh="${RSH_STRING}" output/ ${HOST}:~/"${DEST}"
 
 # Run nikola's post deploy hooks
-rsync -rav --delete --rsh="${RSH_STRING}" russianfedora.pro:~/"${DEST}"/cache cache/ || true
+rsync -rav --delete --rsh="${RSH_STRING}" ${HOST}:~/"${DEST}"/cache cache/ || true
 nikola deploy
-rsync -rav --delete --rsh="${RSH_STRING}" cache/ russianfedora.pro:~/"${DEST}"/cache
+rsync -rav --delete --rsh="${RSH_STRING}" cache/ ${HOST}:~/"${DEST}"/cache


### PR DESCRIPTION
Host hardcoded to the IP address. Current host is provided by @bookwar.
G+ comments are no longer available.